### PR TITLE
Fix the bootstrap shim working directory.

### DIFF
--- a/bootstrap-shim.js
+++ b/bootstrap-shim.js
@@ -3,6 +3,7 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 
+process.chdir(__dirname);
 const target = "./build/index.js";
 try {
 	if (!fs.existsSync(target)) {


### PR DESCRIPTION
This allows calling development versions of the Action from external repositories, rather than just from the current repository.